### PR TITLE
Use any 2.x.x version of unrest.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "tests"
   ],
   "dependencies": {
-    "unrest": "~2.0.1"
+    "unrest": "^2.0.1"
   },
   "devDependencies": {
     "angular": "~1.4.8",


### PR DESCRIPTION
The ~ locks down both major and minor versions.
The ^ only locks down the major.
